### PR TITLE
feat-breadcrumb updated

### DIFF
--- a/frontend/src/app/core/layout/main-layout/main-layout.component.html
+++ b/frontend/src/app/core/layout/main-layout/main-layout.component.html
@@ -3,6 +3,9 @@
   <!-- Header -->
   <app-header (menuToggle)="toggleSidenav()"></app-header>
 
+  <!-- Breadcrumb Navigation -->
+  <app-breadcrumb></app-breadcrumb>
+
   <!-- Sidenav Container -->
   <mat-sidenav-container class="sidenav-container">
     <!-- Sidebar -->

--- a/frontend/src/app/core/layout/main-layout/main-layout.component.ts
+++ b/frontend/src/app/core/layout/main-layout/main-layout.component.ts
@@ -11,6 +11,7 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { HeaderComponent } from '../header/header.component';
 import { SidebarComponent } from '../sidebar/sidebar.component';
 import { ThemeService } from '../../services/theme.service';
+import { BreadcrumbComponent } from '../../../shared/components/breadcrumb/breadcrumb.component';
 
 @Component({
   selector: 'app-main-layout',
@@ -21,6 +22,7 @@ import { ThemeService } from '../../services/theme.service';
     LayoutModule,
     HeaderComponent,
     SidebarComponent,
+    BreadcrumbComponent,
   ],
   templateUrl: './main-layout.component.html',
   styleUrls: ['./main-layout.component.scss'],

--- a/frontend/src/app/features/website/components/website-navbar/website-navbar.component.html
+++ b/frontend/src/app/features/website/components/website-navbar/website-navbar.component.html
@@ -15,6 +15,7 @@
       <button mat-icon-button class="btn-theme" (click)="toggleTheme()" [matTooltip]="themeTooltip()">
         <mat-icon>{{ themeIcon() }}</mat-icon>
       </button>
+      <!-- TODO: Achange admin to login -->
       <button mat-stroked-button class="btn-back-admin" (click)="goToAdmin()">
         <mat-icon>arrow_back</mat-icon> Admin
       </button>

--- a/frontend/src/app/features/website/website.routes.ts
+++ b/frontend/src/app/features/website/website.routes.ts
@@ -7,5 +7,6 @@ export const WEBSITE_ROUTES: Routes = [
       import('./components/website-shell/website-shell.component').then(
         (m) => m.WebsiteShellComponent
       ),
+    data: { title: 'Website' },
   },
 ];

--- a/frontend/src/app/shared/components/breadcrumb/breadcrumb.component.ts
+++ b/frontend/src/app/shared/components/breadcrumb/breadcrumb.component.ts
@@ -1,0 +1,113 @@
+import { Component, inject, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { SharedMaterialModule } from '../../shared-material.module';
+import { BreadcrumbService } from '../../services/breadcrumb.service';
+
+@Component({
+  selector: 'app-breadcrumb',
+  standalone: true,
+  imports: [CommonModule, RouterModule, SharedMaterialModule],
+  template: `
+    <nav class="breadcrumb-container" aria-label="breadcrumb">
+      <div class="breadcrumb-wrapper">
+        @for (crumb of breadcrumbs(); track crumb.url; let isLast = $last) {
+          @if (crumb.isClickable) {
+            <a
+              [routerLink]="crumb.url"
+              class="breadcrumb-link"
+              [attr.aria-current]="isLast ? 'page' : null"
+            >
+              @if (crumb.icon) {
+                <mat-icon class="breadcrumb-icon">{{ crumb.icon }}</mat-icon>
+              }
+              <span>{{ crumb.label }}</span>
+            </a>
+          } @else {
+            <span class="breadcrumb-current" aria-current="page">
+              @if (crumb.icon) {
+                <mat-icon class="breadcrumb-icon">{{ crumb.icon }}</mat-icon>
+              }
+              <span>{{ crumb.label }}</span>
+            </span>
+          }
+          @if (!isLast) {
+            <mat-icon class="breadcrumb-separator">chevron_right</mat-icon>
+          }
+        }
+      </div>
+    </nav>
+  `,
+  styles: [
+    `
+      .breadcrumb-container {
+        background-color: var(--background-secondary);
+        border-bottom: 1px solid var(--border-color);
+        padding: 8px 24px;
+      }
+
+      @media (max-width: 768px) {
+        .breadcrumb-container {
+          display: none;
+        }
+      }
+
+      .breadcrumb-wrapper {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+        max-width: 1400px;
+        margin: 0 auto;
+      }
+
+      .breadcrumb-link,
+      .breadcrumb-current {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        font-size: 13px;
+        text-decoration: none;
+        transition: color 0.2s ease;
+      }
+
+      .breadcrumb-link {
+        color: var(--text-secondary);
+        cursor: pointer;
+      }
+
+      .breadcrumb-link:hover {
+        color: var(--primary-color);
+        text-decoration: underline;
+      }
+
+      .breadcrumb-link:hover .breadcrumb-icon {
+        color: var(--primary-color);
+      }
+
+      .breadcrumb-current {
+        color: var(--text-primary);
+        font-weight: 500;
+      }
+
+      .breadcrumb-icon {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+        color: inherit;
+      }
+
+      .breadcrumb-separator {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+        color: var(--text-secondary);
+      }
+    `,
+  ],
+})
+export class BreadcrumbComponent {
+  private breadcrumbService = inject(BreadcrumbService);
+
+  breadcrumbs = computed(() => this.breadcrumbService.getBreadcrumbs());
+}

--- a/frontend/src/app/shared/models/breadcrumb.model.ts
+++ b/frontend/src/app/shared/models/breadcrumb.model.ts
@@ -1,0 +1,6 @@
+export interface BreadcrumbItem {
+  label: string;
+  url: string;
+  isClickable: boolean;
+  icon?: string;
+}

--- a/frontend/src/app/shared/services/breadcrumb.service.ts
+++ b/frontend/src/app/shared/services/breadcrumb.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
+import { filter } from 'rxjs/operators';
+import { BreadcrumbItem } from '../models/breadcrumb.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BreadcrumbService {
+  private router = inject(Router);
+  private activatedRoute = inject(ActivatedRoute);
+
+  breadcrumbs = signal<BreadcrumbItem[]>([]);
+
+  constructor() {
+    this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe(() => {
+        this.breadcrumbs.set(this.createBreadcrumbs(this.activatedRoute.root));
+      });
+  }
+
+  private createBreadcrumbs(
+    route: ActivatedRoute,
+    url: string = '',
+    breadcrumbs: BreadcrumbItem[] = []
+  ): BreadcrumbItem[] {
+    // Add home/dashboard as first item if we're not already there
+    if (breadcrumbs.length === 0 && url !== '/dashboard') {
+      breadcrumbs.push({
+        label: 'Home',
+        url: '/dashboard',
+        isClickable: true,
+        icon: 'home',
+      });
+    }
+
+    const children: ActivatedRoute[] = route.children;
+
+    if (children.length === 0) {
+      return breadcrumbs;
+    }
+
+    for (const child of children) {
+      const routeURL: string = child.snapshot.url
+        .map((segment) => segment.path)
+        .join('/');
+
+      if (routeURL !== '') {
+        url += `/${routeURL}`;
+      }
+
+      const label = child.snapshot.data['title'];
+
+      if (label && !breadcrumbs.some((crumb) => crumb.label === label)) {
+        breadcrumbs.push({
+          label,
+          url,
+          isClickable: true,
+        });
+      }
+
+      return this.createBreadcrumbs(child, url, breadcrumbs);
+    }
+
+    return breadcrumbs;
+  }
+
+  /**
+   * Mark the last breadcrumb as not clickable (current page)
+   */
+  getBreadcrumbs(): BreadcrumbItem[] {
+    const crumbs = this.breadcrumbs();
+    if (crumbs.length > 0) {
+      return crumbs.map((crumb, index) => ({
+        ...crumb,
+        isClickable: index < crumbs.length - 1,
+      }));
+    }
+    return crumbs;
+  }
+}


### PR DESCRIPTION
## Summary
Added breadcrumb navigation component across all features with automatic route-based generation.

## Changes
- Created `BreadcrumbComponent` with simple link-based design
- Created `BreadcrumbService` for route tracking and breadcrumb generation
- Integrated into `MainLayoutComponent` below header
- Added missing route titles in `website.routes.ts`

## Features
✅ Home icon navigation to dashboard
✅ Clickable navigation (all except current page)
✅ Auto-generated from route `data.title`
✅ Hidden on mobile viewports (< 768px)
✅ Theme-aware styling using CSS custom properties

**Files Added:**
- `frontend/src/app/shared/components/breadcrumb/breadcrumb.component.ts`
- `frontend/src/app/shared/services/breadcrumb.service.ts`
- `frontend/src/app/shared/models/breadcrumb.model.ts`

**Files Modified:**
- `frontend/src/app/core/layout/main-layout/main-layout.component.{ts,html}`
- `frontend/src/app/features/website/website.routes.ts`