### PR TITLE
Mobile view update

### DIFF
--- a/frontend/src/app/features/dashboard/main-dashboard.component.html
+++ b/frontend/src/app/features/dashboard/main-dashboard.component.html
@@ -34,9 +34,11 @@
                 <span class="module-name">{{ module.title }}</span>
               </div>
             </mat-panel-title>
-            <mat-panel-description>
+           <div class="panel-title-description">
+              <mat-panel-description>
               {{ module.description }}
             </mat-panel-description>
+           </div>
           </mat-expansion-panel-header>
 
           <!-- Panel Body: Stats Row -->

--- a/frontend/src/app/features/dashboard/main-dashboard.component.scss
+++ b/frontend/src/app/features/dashboard/main-dashboard.component.scss
@@ -206,6 +206,10 @@
     }
   }
 
+  .panel-title-description {
+    display: none;
+  }
+
   .stats-row {
     flex-direction: column;
   }


### PR DESCRIPTION
in the main-dashboard, there is an element with class mat-expansion-panel-header-description this should be hidden in the mobile view.

ISSUE No: - https://github.com/yps-academy-udgir/yps-academy-web/issues/135